### PR TITLE
Fix typos in description Görli => Göerli

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -5,7 +5,7 @@
   "upstreamRepo": "ethereum/go-ethereum",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "A cross-client PoA testing network for Ethereum",
-  "description": "Geth version for the Görli Testnet. Görli Testnet is the first proof-of-authority cross-client testnet, synching Parity Ethereum, Geth, Nethermind, Pantheon, and EthereumJS. This testnet is a community-based project, completely open-source, naturally. It was born in September 2018 during ETHBerlin and has been growing in contributors ever since. More info [here](https://goerli.net/). \n\n      .---------.\n      |.-------.|\n      ||>run#  ||\n      ||       ||\n      |'-------'|\n    .-^---------^-.\n    |Görli Testnet|\n    '-------------'\n",
+  "description": "Geth version for the Göerli Testnet. Göerli Testnet is the first proof-of-authority cross-client testnet, synching Parity Ethereum, Geth, Nethermind, Pantheon, and EthereumJS. This testnet is a community-based project, completely open-source, naturally. It was born in September 2018 during ETHBerlin and has been growing in contributors ever since. More info [here](https://goerli.net/). \n\n      .---------.\n      |.-------.|\n      ||>run#  ||\n      ||       ||\n      |'-------'|\n    .-^---------^-.\n    |Göerli Testnet|\n    '-------------'\n",
   "type": "library",
   "chain": "ethereum",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",


### PR DESCRIPTION
The package description has Göerli mispelled as Görli in a couple spots in the text descriptor, i have just added the missing "e" in each instance.  All code mentions of Göerli have it spelled correctly and were left untouched.