### PR TITLE
Change default syncmode to snap fast is deprecated

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ ARG UPSTREAM_VERSION
 
 FROM ethereum/client-go:${UPSTREAM_VERSION}
 
-ENTRYPOINT geth --datadir /goerli --goerli --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-fast} --metrics --metrics.addr 0.0.0.0 $EXTRA_OPTIONS
+ENTRYPOINT geth --datadir /goerli --goerli --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-snap} --metrics --metrics.addr 0.0.0.0 $EXTRA_OPTIONS
 
 
 


### PR DESCRIPTION
changed the default sync mode to snap as necessary for Geth v1.10.14 since the current default sync mode fast bloom sync is now deprecated in v1.10.14